### PR TITLE
Ashiq/decompose save

### DIFF
--- a/docs/GeneratingIndividualAssets.md
+++ b/docs/GeneratingIndividualAssets.md
@@ -55,6 +55,9 @@ python -m infinigen_examples.generate_individual_assets --output_folder outputs/
 
 # See the full list of supported formats
 python -m infinigen_examples.generate_individual_assets --help
+
+# To break down the mesh into its basic constituents
+python -m infinigen_examples.generate_individual_assets --output_folder outputs/bush -f BushFactory -n 1 --render none --export usdc --decompose
 ```
 
 

--- a/infinigen_examples/generate_individual_assets.py
+++ b/infinigen_examples/generate_individual_assets.py
@@ -365,10 +365,6 @@ def build_and_save_asset(payload: dict):
     if args.decompose:
         separate_loose_parts_and_make_rigid()
 
-    if args.rename:
-        breakpoint()
-        bpy.ops.wm.window_fullscreen_toggle()
-
     if args.save_blend:
         butil.save_blend(output_folder / "scene.blend", autopack=True)
         tag_system.save_tag(output_folder / "MaskTag.json")
@@ -612,9 +608,6 @@ def make_args():
         "--decompose",
         action="store_true",
         help="To decompose the object in its constituents",
-    )
-    parser.add_argument(
-        "--rename", action="store_true", help="To drename objects manually"
     )
     parser.add_argument(
         "-e", "--elevation", default=60, type=float, help="Elevation of the sun"


### PR DESCRIPTION
Fix: Break Down Single Body Mesh into its Constituents

While creating individual assets, the output was initially generated as a single body. To effectively track the pose of different body parts and to make articulations possible in Isaacsim, the mesh needed to be broken down into its basic constituents. This change ensures more accurate pose representation and better manipulation of individual components.